### PR TITLE
84 Update CEP18 Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,47 +1,39 @@
 # Casper Fungible Tokens (CEP-18 Standard)
 
-A library for developing fungible tokens (CEP-18 Tokens) tokens for the Casper Network.
+This repository contains a reference contract implementation and tests for fungible tokens on a Casper network, following the [CEP-18 standard](https://github.com/casper-network/ceps/pull/18).
 
-The main functionality is provided via the CEP-18 struct, and is intended to be consumed by a smart contract written to be deployed on the Casper Network.
+## Preparation
 
-## Development
-
-Make sure the `wasm32-unknown-unknown` Rust target is installed.
+Install the `wasm32-unknown-unknown` Rust target with the following command.
 
 ```
 make prepare
 ```
 
-## Build Smart Contracts
+## Building and Testing the Contract
 
-To build the example fungible token contract and supporting test contracts:
-
-```
-make build-contracts
-```
-
-## Locating Smart Contract Wasm
-
-The Wasm for your new project can be found in the following local directory:
-
-```
-casper/cep18/target/wasm32-unknown-unknown/release/cep18_token.wasm
-```
-
-## Test
+To build the reference fungible token contract and supporting tests, run this command:
 
 ```
 make test
 ```
 
-## JavaScript Client SDK
+## Locating the Contract Wasm
 
-A [JavaScript client SDK](https://github.com/casper-ecosystem/erc20/tree/master/client-js#readme) can be used to interact with the fungible token contract.
+Find the Wasm for the contract in the following directory:
 
-## Documentation
+```
+casper/cep18/target/wasm32-unknown-unknown/release/cep18_token.wasm
+```
 
-For more information, visit the below guides:
+## A JavaScript Client SDK
 
-- [Casper Fungible Token Tutorial](/docs/TUTORIAL.md) - An illustrated guide on how to implement, deploy, and test an fungible token contract.
-- [Casper Fungible Token How-To Guide](/docs/Sample-Guide.md) - An example-driven guide on how to setup, query, transfer, approve, and check the balance of an fungible token contract.
-- [Casper Fungible Token Quick Deploying Guide](/docs/Deploy-Token.md) - A quick guide on how to deploy the Casper fungible token to the Casper Network.
+A [JavaScript client SDK](https://github.com/casper-ecosystem/cep18/tree/master/client-js#readme) has been provided to interact with the fungible token contract.
+
+## Tutorials
+
+For more information, visit the links below:
+
+- [The Casper Fungible Token Developer Tutorial](/docs/TUTORIAL.md) - How to implement, deploy, and test a fungible token contract.
+- [The Casper Fungible Token Usage Guide](/docs/Sample-Guide.md) - An example-driven guide on how to set up, query, transfer, approve, and check the balance of a fungible token contract.
+- [The Casper Fungible Token Quick Deploying Guide](/docs/Deploy-Token.md) - How to deploy the Casper fungible token to a Casper network.

--- a/cep18/Cargo.toml
+++ b/cep18/Cargo.toml
@@ -2,7 +2,7 @@
 name = "casper-cep18"
 version = "1.0.0"
 edition = "2018"
-description = "A library for developing CEP18 tokens for the Casper network."
+description = "A library for developing CEP-18 tokens for the Casper network."
 readme = "README.md"
 documentation = "https://docs.rs/casper-cep18"
 homepage = "https://casperlabs.io"

--- a/cep18/README.md
+++ b/cep18/README.md
@@ -16,8 +16,6 @@
 
 The fungible token implementation supports a couple of `modalities` that dictate the behavior of a specific contract instance. Modalities represent the common expectations around contract usage and behavior. The following section discusses the modalities currently available.
 
-<!-- TODO verify that these modalities canNOT be changed after installation. -->
-
 ### EventsMode
 
 The `EventsMode` modality determines how the installed instance of CEP-18 will handle the recording of events that occur from interacting with the contract. The mode is set by passing a `u8` value to the `events_mode` runtime argument: `--session-arg "events_mode:u8='1'"`. The default behavior is `NoEvents`.
@@ -39,13 +37,9 @@ The modality provides two options:
 
 `CES` is an option within the `EventsMode` modality that determines how changes to tokens issued by the contract instance will be recorded. Changes are recorded in the `__events` dictionary and can be observed via a node's Server Side Events stream. They may also be viewed by querying the dictionary at any time using the JSON-RPC interface.
 
-<!-- TODO who creates this dictionary? Is it created and managed by the casper_event_standard crate? -->
-
 The emitted events are encoded according to the [Casper Event Standard](https://github.com/make-software/casper-event-standard), and the schema is visible to an observer reading the `__events_schema` contract named key.
 
 For this CEP-18 reference implementation, the events schema is as follows:
-
-<!-- TODO check this table with the dev team. I've extracted from src/events.rs -->
 
 | Event name        | Included values and their type                                 |
 | ----------------- | -------------------------------------------------------------- |
@@ -141,8 +135,6 @@ This repository contains several ways of testing the fungible token contract and
 
 
 ## Error Codes
-
-<!-- TODO check with the dev team if these explanations are correct. I've extracted from the code. -->
 
 The table below summarizes the [error codes](./src/error.rs) you may see while working with fungible tokens.
 

--- a/cep18/README.md
+++ b/cep18/README.md
@@ -55,7 +55,7 @@ For this CEP-18 reference implementation, the events schema is as follows:
 
 ### MintBurn
 
-The `MintBurn` modality dictates whether tokens managed by a given instance of a CEP-18 contract can be minted or burnt after contract installation. 
+The `MintBurn` modality dictates whether tokens managed by a given instance of a CEP-18 contract can be minted or burned after contract installation. 
 
 **IMPORTANT: This mode cannot be changed once the contract has been installed.**
 

--- a/cep18/README.md
+++ b/cep18/README.md
@@ -1,3 +1,173 @@
-# casper-cep18
+# CEP-18: The Casper Fungible Token Standard
 
-A library for developing CEP18 tokens for the Casper network.
+## Table of Contents
+
+1. [Modalities](#modalities)
+
+2. [Entry Points](#entry-points)
+
+3. [Testing](#testing)
+
+4. [Error Codes](#error-codes)
+
+5. [Usage](#usage)
+
+## Modalities
+
+The fungible token implementation supports a couple of `modalities` that dictate the behavior of a specific contract instance. Modalities represent the common expectations around contract usage and behavior. The following section discusses the modalities currently available.
+
+<!-- TODO verify that these modalities canNOT be changed after installation. -->
+
+### EventsMode
+
+The `EventsMode` modality determines how the installed instance of CEP-18 will handle the recording of events that occur from interacting with the contract. The mode is set by passing a `u8` value to the `events_mode` runtime argument: `--session-arg "events_mode:u8='1'"`. The default behavior is `NoEvents`.
+
+**IMPORTANT: This mode cannot be changed once the contract has been installed.**
+
+The modality provides two options:
+
+1. `NoEvents`: This modality will signal the contract not to record events. This is the default mode.
+2. `CES`: This modality will signal the contract to record events using the [Casper Event Standard (CES)](#casper-event-standard).
+
+| EventsMode | u8  |
+| ---------- | --- |
+| NoEvents   | 0   |
+| CES        | 1   |
+
+
+#### The Casper Event Standard
+
+`CES` is an option within the `EventsMode` modality that determines how changes to tokens issued by the contract instance will be recorded. Changes are recorded in the `__events` dictionary and can be observed via a node's Server Side Events stream. They may also be viewed by querying the dictionary at any time using the JSON-RPC interface.
+
+<!-- TODO who creates this dictionary? Is it created and managed by the casper_event_standard crate? -->
+
+The emitted events are encoded according to the [Casper Event Standard](https://github.com/make-software/casper-event-standard), and the schema is visible to an observer reading the `__events_schema` contract named key.
+
+For this CEP-18 reference implementation, the events schema is as follows:
+
+<!-- TODO check this table with the dev team. I've extracted from src/events.rs -->
+
+| Event name        | Included values and their type                                 |
+| ----------------- | -------------------------------------------------------------- |
+| Mint              | recipient (Key), amount (U256)                                 |
+| Burn              | owner (Key), amount (U256)                                     |
+| SetAllowance      | owner (Key), spender (Key), allowance (U256)                   |
+| IncreaseAllowance | owner (Key), spender (Key), allowance (U256), inc_by (U256)    |
+| DecreaseAllowance | owner (Key), spender (Key), allowance (U256), decr_by (U256)   |
+| Transfer          | sender (Key), recipient (Key), amount (U256)                   |
+| TransferFrom      | spender (Key), owner (Key), recipient (Key), amount (U256)     |
+| ChangeSecurity    | pub admin (Key), sec_change_map (BTreeMap<Key, SecurityBadge>) |
+
+
+### MintBurn
+
+The `MintBurn` modality dictates whether tokens managed by a given instance of a CEP-18 contract can be minted or burnt after contract installation. 
+
+**IMPORTANT: This mode cannot be changed once the contract has been installed.**
+
+This modality provides two options:
+
+1. `Disabled`: Tokens cannot be minted nor burnt after contract installation. This is the default mode.
+2. `MintAndBurn`: Tokens can be minted and burnt.
+
+| MintBurn    | u8  |
+| ----------- | --- |
+| Disabled    | 0   |
+| MintAndBurn | 1   |
+
+This modality is specified by providing an optional runtime argument during installation. The mode is set by passing a `u8` value to the `enable_mint_burn` runtime argument: `--session-arg "enable_mint_burn:u8='1'"`. The default behavior is `Disabled`.
+
+### Example Installation
+
+Here is a sample deploy installing a fungible token with event logging and minting and burning enabled:
+
+```bash
+casper-client put-deploy \
+--node-address http://65.21.235.219:7777  \
+--chain-name casper-test \
+--secret-key ~/KEYS/secret_key.pem \
+--payment-amount 120000000000 \
+--session-path ./target/wasm32-unknown-unknown/release/cep18.wasm \
+--session-arg "name:string='Test Token'" \
+--session-arg "symbol:string='DEMO'" \
+--session-arg "total_supply:u256='100'" \
+--session-arg "decimals:u8='2'" \
+--session-arg "events_mode:u8='1'" \
+--session-arg "enable_mint_burn:u8='1'"
+```
+
+## Entry Points
+
+The Casper CEP-18 Standard follows the [ERC20 Standard](https://eips.ethereum.org/EIPS/eip-20) by implementing the IERC20 interface. The explanations below are summarized from the ERC20 set of interfaces, contracts, and utilities found [here](https://docs.openzeppelin.com/contracts/4.x/api/token/erc20).
+
+* `init` - Entrypoint called only once during contract installation.
+* `allowance` - Returns the number of tokens that a spender can spend on behalf of the owner. The default is zero until `approve` or `transferFrom` are called.
+* `increase_allowance` - Increases the allowance granted to a spender by the caller. This is an alternative to `approve`.
+* `decrease_allowance` - Decreases the allowance granted to a spender by the caller. This is an alternative to `approve`.
+* `approve` - Sets a spender's allowance over the caller’s tokens.
+* `balance_of` - Returns the number of tokens owned by the account specified.
+* `decimals` - Returns the number of decimals used to represent the token to a user. For example, if `decimals` equals `2`, a balance of `505` tokens should be displayed to a user as `5.05`.
+* `name` - Returns the name of the token.
+* `symbol` - Returns the symbol of the token, usually a shorter version of the name; for example, CSPR.
+* `total_supply` - Returns the number of tokens in existence.
+* `transfer` - Moves tokens from the caller to the specified recipient. 
+* `transfer_from` - Moves tokens from the owner to a recipient if the caller has been approved to spend the owner's tokens.
+* `mint` - Creates the number of tokens specified and assigns them to an account, increasing the total supply.
+* `burn` - Destroys the number of tokens specified from an account, reducing the total supply.
+* `change_security` - An entrypoint specific to CEP-18, used for Administration and Security operations. See more details below.
+
+### Changing Security Access
+
+The `change_security` entrypoint manages the security access granted to users. One user can only possess one access group badge. The groups and the change strength are: 
+
+* None > Admin > MintAndBurn > Burner > Minter
+
+For example, if a user is added to both Minter and Admin, they will be an Admin.
+If a user is added to Admin and None, they will be removed from having access rights.
+
+**IMPORTANT: do NOT remove the last Admin, because that will lock out all admin functionality.**
+
+## Testing
+
+This repository contains several ways of testing the fungible token contract and its entrypoints.
+
+1. The test suite found in the [tests](../tests/) folder asserts the expected behavior of the contract implementation. It also ensures that no regressions and conflicting behaviors are introduced as functionality is added or extended. The tests can be run by using the provided `Makefile` and running the `make test` command.
+
+2. A test contract that calls the entrypoints in the fungible token contract is also available in the [cep18-test-contract](../cep18-test-contract/) folder.
+
+3. The JavaScript client in the [client-js](../client-js/README.md) folder has unit tests and end-to-end integration tests.
+
+4. A set of benchmarking scripts is also available in the [cost-benchmarking](../cost-benchmarking/README.md) folder, for testing gas costs of basic operations.
+
+
+## Error Codes
+
+<!-- TODO check with the dev team if these explanations are correct. I've extracted from the code. -->
+
+The table below summarizes the [error codes](./src/error.rs) you may see while working with fungible tokens.
+
+| Code  | Error                  | Description                                             |
+| ----- | ---------------------- | --------------------------------------------------------|
+| 60000 | InvalidContext         | The contract was called from within an invalid context. |
+| 60001 | InsufficientBalance    | The spender does not have enough funds.                 |
+| 60002 | InsufficientAllowance  | The spender does not have enough allowance approved.    |
+| 60003 | Overflow               | This operation would cause an integer overflow.         |
+| 60004 | PackageHashMissing     | A required package hash was not specified.              |
+| 60005 | PackageHashNotPackage  | The package hash specified does not represent a package.|
+| 60006 | InvalidEventsMode      | An invalid event mode was specified.                    |
+| 60007 | MissingEventsMode      | The event mode required was not specified.              |
+| 60008 | Phantom                | An unknown error occurred.                              |
+| 60009 | FailedToGetArgBytes    | Failed to read the runtime arguments provided.          |
+| 60010 | InsufficientRights     | The caller does not have sufficient security access.    |
+| 60011 | InvalidAdminList       | The list of Admin accounts provided is invalid.         |
+| 60012 | InvalidMinterList      | The list of accounts that can mint tokens is invalid.   |
+| 60013 | InvalidBurnerList      | The list of accounts that can burn tokens is invalid.   |
+| 60014 | InvalidMintAndBurnList | The list of accounts that can mint and burn is invalid. |
+| 60015 | InvalidNoneList        | The list of accounts with no access rights is invalid.  |
+| 60016 | InvalidEnableMBFlag    | The flag to enable the mint and burn mode is invalid.   |
+| 60017 | AlreadyInitialized     | This contract instance cannot be initialized again.     |
+| 60018 | MintBurnDisabled       | The mint and burn mode is disabled.                     |
+
+### Usage
+
+For installing and interacting with the fungible token reference contract, read the examples provided in the [docs](../docs) folder.

--- a/cep18/README.md
+++ b/cep18/README.md
@@ -62,7 +62,7 @@ The `MintBurn` modality dictates whether tokens managed by a given instance of a
 This modality provides two options:
 
 1. `Disabled`: Tokens cannot be minted nor burned after contract installation. This is the default mode.
-2. `MintAndBurn`: Tokens can be minted and burnt.
+2. `MintAndBurn`: Tokens can be minted and burned.
 
 | MintBurn    | u8  |
 | ----------- | --- |

--- a/cep18/README.md
+++ b/cep18/README.md
@@ -61,7 +61,7 @@ The `MintBurn` modality dictates whether tokens managed by a given instance of a
 
 This modality provides two options:
 
-1. `Disabled`: Tokens cannot be minted nor burnt after contract installation. This is the default mode.
+1. `Disabled`: Tokens cannot be minted nor burned after contract installation. This is the default mode.
 2. `MintAndBurn`: Tokens can be minted and burnt.
 
 | MintBurn    | u8  |

--- a/cep18/src/constants.rs
+++ b/cep18/src/constants.rs
@@ -1,4 +1,4 @@
-//! Constants used by the CEP18 contract.
+//! Constants used by the CEP-18 contract.
 
 /// Name of named-key for `name`.
 pub const NAME: &str = "name";

--- a/cep18/src/entry_points.rs
+++ b/cep18/src/entry_points.rs
@@ -214,7 +214,7 @@ pub fn init() -> EntryPoint {
     )
 }
 
-/// Returns the default set of CEP18 token entry points.
+/// Returns the default set of CEP-18 token entry points.
 pub fn generate_entry_points() -> EntryPoints {
     let mut entry_points = EntryPoints::new();
     entry_points.add_entry_point(init());

--- a/cep18/src/error.rs
+++ b/cep18/src/error.rs
@@ -1,17 +1,17 @@
-//! Error handling on the casper platform.
+//! Error handling on the Casper platform.
 use casper_types::ApiError;
 
-/// Errors which can be returned by the library.
+/// Errors that the contract can return.
 ///
 /// When an `Error` is returned from a smart contract, it is converted to an [`ApiError::User`].
 ///
-/// Where a smart contract consuming this library needs to define further error variants, it can
+/// While the code consuming this contract needs to define further error variants, it can
 /// return those via the [`Error::User`] variant or equivalently via the [`ApiError::User`]
 /// variant.
 #[repr(u16)]
 #[derive(Clone, Copy)]
 pub enum Cep18Error {
-    /// CEP18 contract called from within an invalid context.
+    /// CEP-18 contract called from within an invalid context.
     InvalidContext = 60000,
     /// Spender does not have enough balance.
     InsufficientBalance = 60001,
@@ -19,20 +19,35 @@ pub enum Cep18Error {
     InsufficientAllowance = 60002,
     /// Operation would cause an integer overflow.
     Overflow = 60003,
+    /// A required package hash was not specified.
     PackageHashMissing = 60004,
+    /// The package hash specified does not represent a package.
     PackageHashNotPackage = 60005,
+    /// An invalid event mode was specified.
     InvalidEventsMode = 60006,
+    /// The event mode required was not specified.
     MissingEventsMode = 60007,
+    /// An unknown error occurred.
     Phantom = 60008,
+    /// Failed to read the runtime arguments provided.
     FailedToGetArgBytes = 60009,
+    /// The caller does not have sufficient security access.
     InsufficientRights = 60010,
+    /// The list of Admin accounts provided is invalid.
     InvalidAdminList = 60011,
+    /// The list of accounts that can mint tokens is invalid.
     InvalidMinterList = 60012,
+    ///  The list of accounts that can burn tokens is invalid.
     InvalidBurnerList = 60013,
+    /// The list of accounts that can mint and burn is invalid.
     InvalidMintAndBurnList = 60014,
+    /// The list of accounts with no access rights is invalid.
     InvalidNoneList = 60015,
+    /// The flag to enable the mint and burn mode is invalid.
     InvalidEnableMBFlag = 60016,
+    /// This contract instance cannot be initialized again.
     AlreadyInitialized = 60017,
+    ///  The mint and burn mode is disabled.
     MintBurnDisabled = 60018,
 }
 

--- a/cep18/src/utils.rs
+++ b/cep18/src/utils.rs
@@ -50,7 +50,7 @@ fn call_stack_element_to_address(call_stack_element: CallStackElement) -> Key {
         CallStackElement::Session { account_hash } => Key::from(account_hash),
         CallStackElement::StoredSession { account_hash, .. } => {
             // Stored session code acts in account's context, so if stored session wants to interact
-            // with an CEP18 token caller's address will be used.
+            // with an CEP-18 token caller's address will be used.
             Key::from(account_hash)
         }
         CallStackElement::StoredContract {

--- a/cost-benchmarking/README.md
+++ b/cost-benchmarking/README.md
@@ -1,27 +1,23 @@
-NCTL cost benchmarking scripts
-======================
+# NCTL Cost Benchmarking Scripts
 
-These scripts deploy and operate the basic CEP18 contract to record gas costs of basic operations. Output is written to `cep18-cost-benchmarking-output` in the repo root directory.
+These scripts deploy and operate a basic CEP-18 contract to record the gas costs of basic operations. Output is written to `cep18-cost-benchmarking-output` in the repository's root directory.
 
-Assumptions
------------
-- running NCTL network with casper-node version 1.4.4 or later
-- user 1 with sufficient tokens (normally the case!)
+## Prerequisites
+- a running NCTL network with casper-node version 1.4.4 or later
+- user 1 with sufficient tokens (usually the case!)
 - users 1-3 available
 - user 1 always acts as the installer
 
-Scripts
--------------------
+## Scripts
+
+The first script makes sure that the contract is compiled, installs it, and records the cost of installation:
 
 `example/cost-benchmarking/prepare.sh`
 
-Makes sure that the contract is compiled, installs it and records the cost of installation.
+The second script exercises all entry points with different amounts and records the costs.
 
 `example/cost-benchmarking/run-benchmarks.sh`
 
-Exercises all entry points with different amounts specified and records the costs.
+## Typical Operation
 
-Typical operation
--------------------
-
-Invoke `. example/prepare.sh` from repo root, then invoke `. example/run-benchmarks.sh` if needed.
+Invoke `. example/prepare.sh` from the repository's root, then invoke `. example/run-benchmarks.sh` if needed.


### PR DESCRIPTION
Closes #84 

I thought it would be better to merge my two working branches due to some cross-linking.

@deuszex, please help review the following:
- The main contribution to this PR is the cep18 contract README (7080e823f16cf4f94c33ddea7bb2b190fe1ec4a5)
- Additional explanations for the error codes (26f90f3d1290d8bd4cc474fabd1afb1b985f35e6)
- Also, please check the following notes (fb23e91dc7e3f6bb33fa1f535e506b010974b003):
   - the two modalities can not be changed after installation
   - the table listing the events schema 
   - the table summarizing the error codes 
   - the casper_event_standard crate manages the dictionary storing events

@ACStoneCL, please review the overall documentation updates.

Just FYI, @hoffmannjan and @gyroflaw.